### PR TITLE
Validate "0" alpha

### DIFF
--- a/src/validate-color/index.js
+++ b/src/validate-color/index.js
@@ -164,7 +164,7 @@ export const validateHTMLColorName = color => {
 export const validateHTMLColor = color => {
   // Only do any of this if 'color' is a string
   if (typeof color === 'string') {
-    const regex = /^#([\da-f]{3}){1,2}$|^#([\da-f]{4}){1,2}$|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*,?\s*\)?)(,\s*(0?\.\d+)?|1)?\)$/i;
+    const regex = /^#([\da-f]{3}){1,2}$|^#([\da-f]{4}){1,2}$|(rgb|hsl)a?\((\s*-?\d+%?\s*,){2}(\s*-?\d+%?\s*,?\s*\)?)(,\s*(0?\.\d+)?|1|0)?\)$/i;
     return (
       color && regex.test(color)
         ? true

--- a/src/validate-color/index.test.js
+++ b/src/validate-color/index.test.js
@@ -240,6 +240,11 @@ describe('validateHTMLColor', () => {
       const validation = validateHTMLColor(color);
       expect(validation).toBe(true);
     })
+    it('validates "rgba(100,100,100,0)"', () => {
+      const color = 'rgba(100,100,100,0)';
+      const validation = validateHTMLColor(color);
+      expect(validation).toBe(true);
+    })
     it('validates "hsl(0, 0, 0)"', () => {
       const color = 'hsl(0, 0, 0)';
       const validation = validateHTMLColor(color);


### PR DESCRIPTION
Hi, thanks for the library, I am using it in one of my projects. I noticed that it returns false when "0" is the alpha value in rgba, for example "rgba(100,100,100,0)" is said to not be valid. This PR is to correct that.