### PR TITLE
Moved react to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
   },
   "copyright": "Copyright (c) Wallace Sidhrée - All rights reserved.",
   "license": "MIT",
-  "peerDependencies": {
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.12.9",
     "@babel/preset-env": "^7.12.7",
@@ -40,7 +36,9 @@
     "react-emojis": "^1.0.6",
     "react-scripts": "^4.0.1",
     "webpack": "4.44.2",
-    "webpack-cli": "^4.2.0"
+    "webpack-cli": "^4.2.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Stop using react as a peer dependency! by installing this library you install react, and this is not necessary as the library doesn't use it directly in any way.

Since it's only needed for the demo, the right place for it is dev dependencies, in this way react and react-dom won't be installed automatically.